### PR TITLE
Fix the run script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -109,10 +109,6 @@ if [[ -d "/fakenet/" ]]; then
 	sleep 1
 fi
 
-for f in /etc/netdata/override/*; do
-  cp -a $f /etc/netdata/
-done
-
 # main entrypoint
 touch /etc/netdata/python.d.conf
 exec /usr/sbin/netdata -D -u root -s /host -p ${NETDATA_PORT} ${NETDATA_ARGS} "$@"


### PR DESCRIPTION
Removed code in `run.sh` that prevented the container from running because of the error:

`cp: cannot stat '/etc/netdata/override/*': No such file or directory`

I don't understand how no one appears to have encountered this error before me.