### PR TITLE
chore: upgrade to Netdata v1.47.5 and Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 ADD git-tag /git-tag
 

--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MY_IMAGE_NAME="caprover/netdata"
-NETDATA_VERSION="v1.34.1"
+NETDATA_VERSION="v1.47.5"
 
 # ensure you're not running it on local machine
 if [ -z "$CI" ] || [ -z "$GITHUB_REF" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,15 +4,16 @@ DEBIAN_FRONTEND=noninteractive
 
 # some mirrors have issues, i skipped httpredir in favor of an eu mirror
 
-echo "deb http://ftp.nl.debian.org/debian/ stretch main" > /etc/apt/sources.list
-echo "deb http://security.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+echo "deb http://deb.debian.org/debian/ bullseye main" > /etc/apt/sources.list
+echo "deb http://deb.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
+echo "deb http://deb.debian.org/debian/ bullseye-updates main" >> /etc/apt/sources.list
 
 # install dependencies for build
 # source: https://learn.netdata.cloud/docs/agent/packaging/installer/methods/manual
 
 apt-get -qq update
 apt-get -y install zlib1g-dev uuid-dev libmnl-dev gcc make curl git autoconf autogen automake pkg-config netcat-openbsd jq libuv1-dev liblz4-dev libjudy-dev libssl-dev cmake libelf-dev libprotobuf-dev protobuf-compiler g++
-apt-get -y install autoconf-archive lm-sensors nodejs python python-mysqldb python-yaml libjudydebian1 libuv1 liblz4-1 openssl
+apt-get -y install autoconf-archive lm-sensors nodejs python3 python3-mysqldb python3-yaml libjudydebian1 libuv1 liblz4-1 openssl
 apt-get -y install msmtp msmtp-mta apcupsd fping
 
 # fetch netdata


### PR DESCRIPTION
* Motivation *
This PR is made because Netdata used has a memory leak bug and affects currently projects that use caprover latest versions

Netdata memory leak issue:
https://github.com/netdata/netdata/issues/12839


- Upgrade Netdata from v1.34.1 to v1.47.5
- Migrate from Debian Stretch (EOL) to Debian Bullseye
- Update repository URLs to use current Debian mirrors
- Replace Python 2 dependencies with Python 3 equivalents
- Add bullseye-updates repository for better package availability

Debian Stretch reached end-of-life and its repositories are no longer available, causing build failures. This update ensures the build process works with currently supported Debian releases.

Generated by Coding Giang Codes - molBR